### PR TITLE
Fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - go get github.com/skip2/go-qrcode
 
 ## Implement
-- crate file and write to pin code, just like , 21QQ751672(file name) 751672(pin code)
+- create a file and write the pin codes, just like , 21QQ751672(file name) 751672(pin code)
 ```
 19QQ123456
 20QQ234456


### PR DESCRIPTION
## Summary
- fix grammar for file creation instructions
- add missing newline at end of README

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/mitchellh/go-homedir/@v/v1.1.0.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5f1dfd083298df99af4e579a351