### PR TITLE
Set default flags for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 ```
 - command line
 ```
+go run main.go
+
 go run main.go -r pinCodeFile.txt -f file -e .png
 
-go run main.go -file=pinCodeFile.txt -path=file -fileExt=.png
-
--file: must be, write file.
--path: Optional, write folder and qr code image inside there.
--fileExt: Optional, default .ping.
+-r: read file content (default pinCodeFile.txt)
+-f: output folder (default file)
+-e: file extension (default .png)
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,8 +37,8 @@ type flags struct {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&readfile, "readfile", "r", "", "read file content for pin code (default read pinCodeFile.txt)")
-	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "", "create folder (default folder name file)")
+	rootCmd.PersistentFlags().StringVarP(&readfile, "readfile", "r", "pinCodeFile.txt", "read file content for pin code (default pinCodeFile.txt)")
+	rootCmd.PersistentFlags().StringVarP(&folder, "folder", "f", "file", "create folder (default file)")
 	rootCmd.PersistentFlags().StringVarP(&fileExt, "fileExt", "e", ".png", "file extension (default .png)")
 }
 


### PR DESCRIPTION
## Summary
- set default values for `readfile` and `folder`
- document defaults in README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5f0799083299815c3c2f22b7a77