### PR TITLE
Fix fileSize error handling

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -87,7 +87,6 @@ func (fs *flags) generateQRCode() error {
 func (fs *flags) fileSize(pingCode string) (size int64, err error) {
 	fi, err := os.Stat(pingCode)
 	if err != nil {
-		log.Fatal(err)
 		return 0, err
 	}
 	return fi.Size(), nil


### PR DESCRIPTION
## Summary
- remove log.Fatal from fileSize
- return the error instead
- caller already checks returned error

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go fmt ./...` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6843a5f0bb008329b4081608c6579efc