### PR TITLE
Upgrade Go to 1.24 and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 - pin code to qr code image
 
 ## Prerequisite
-- GO v1.14
+- GO v1.24
 - go get github.com/skip2/go-qrcode
 
 ## Implement

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPinCodeInfo(t *testing.T) {
+	fs := &flags{}
+	tests := []struct {
+		name      string
+		input     []string
+		wantName  string
+		wantPin   string
+		wantError bool
+	}{
+		{"single", []string{"123"}, "123", "123", false},
+		{"pair", []string{"abc", "789"}, "abc", "789", false},
+		{"invalid", []string{"a", "b", "c"}, "", "", true},
+	}
+
+	for _, tt := range tests {
+		gotName, gotPin, err := fs.pinCodeInfo(tt.input)
+		if tt.wantError {
+			if err == nil {
+				t.Errorf("%s: expected error", tt.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tt.name, err)
+			continue
+		}
+		if gotName != tt.wantName || gotPin != tt.wantPin {
+			t.Errorf("%s: want %s/%s got %s/%s", tt.name, tt.wantName, tt.wantPin, gotName, gotPin)
+		}
+	}
+}
+
+func TestFileSize(t *testing.T) {
+	fs := &flags{}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(p, []byte("abc"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	size, err := fs.fileSize(p)
+	if err != nil {
+		t.Fatalf("fileSize error: %v", err)
+	}
+	if size != 3 {
+		t.Errorf("expected size 3 got %d", size)
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestCheckFlags(t *testing.T) {
+	// success case
+	readfile = "file.txt"
+	folder = "dir"
+	fileExt = ".png"
+	fs, err := checkFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fs.readfile != readfile || fs.folder != folder || fs.fileExt != fileExt {
+		t.Errorf("returned struct mismatch")
+	}
+
+	// missing readfile
+	readfile = ""
+	_, err = checkFlags()
+	if err == nil {
+		t.Errorf("expected error when readfile empty")
+	}
+
+	// restore for other tests
+	readfile = "file.txt"
+	folder = "dir"
+	fileExt = ".png"
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/water25234/golang-genQRCode
 
-go 1.15
+go 1.24
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0


### PR DESCRIPTION
## Summary
- update documentation to mention Go 1.24
- bump go.mod `go` directive to 1.24
- add basic unit tests for `pinCodeInfo`, `fileSize`, and `checkFlags`

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go fmt ./...` *(fails: go.mod requires go >= 1.24)*
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6843abc12ec4832993043d5cdf63637b